### PR TITLE
Update patches for LLVM 16

### DIFF
--- a/rpm/0001-LLVM-Add-MeeGo-vendor-type.patch
+++ b/rpm/0001-LLVM-Add-MeeGo-vendor-type.patch
@@ -1,19 +1,8 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Ruben De Smet <ruben.de.smet@rubdos.be>
-Date: Sun, 26 Jun 2022 10:48:13 +0200
-Subject: [PATCH] LLVM: Add MeeGo vendor type
-
----
- llvm/include/llvm/ADT/Triple.h    |  3 ++-
- llvm/lib/Support/Triple.cpp       | 12 ++++++++++++
- llvm/unittests/ADT/TripleTest.cpp |  6 ++++++
- 3 files changed, 20 insertions(+), 1 deletion(-)
-
-diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 42277c013035..9e36dfd4d2d5 100644
---- a/llvm/include/llvm/ADT/Triple.h
-+++ b/llvm/include/llvm/ADT/Triple.h
-@@ -165,7 +165,8 @@ public:
+diff --git a/llvm/include/llvm/TargetParser/Triple.h b/llvm/include/llvm/TargetParser/Triple.h
+index 59513fa2f206..5bddc2a52c05 100644
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -180,7 +180,8 @@ public:
      Mesa,
      SUSE,
      OpenEmbedded,
@@ -23,11 +12,11 @@ index 42277c013035..9e36dfd4d2d5 100644
    };
    enum OSType {
      UnknownOS,
-diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index a9afcc9db96a..c4307bf457c7 100644
---- a/llvm/lib/Support/Triple.cpp
-+++ b/llvm/lib/Support/Triple.cpp
-@@ -177,6 +177,7 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
+diff --git a/llvm/lib/TargetParser/Triple.cpp b/llvm/lib/TargetParser/Triple.cpp
+index a68035989a93..ef48f02504ac 100644
+--- a/llvm/lib/TargetParser/Triple.cpp
++++ b/llvm/lib/TargetParser/Triple.cpp
+@@ -188,6 +188,7 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
    case Freescale: return "fsl";
    case IBM: return "ibm";
    case ImaginationTechnologies: return "img";
@@ -35,7 +24,7 @@ index a9afcc9db96a..c4307bf457c7 100644
    case Mesa: return "mesa";
    case MipsTechnologies: return "mti";
    case Myriad: return "myriad";
-@@ -507,6 +508,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+@@ -552,6 +553,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
      .Case("mesa", Triple::Mesa)
      .Case("suse", Triple::SUSE)
      .Case("oe", Triple::OpenEmbedded)
@@ -43,7 +32,7 @@ index a9afcc9db96a..c4307bf457c7 100644
      .Default(Triple::UnknownVendor);
  }
  
-@@ -802,6 +804,9 @@ Triple::Triple(const Twine &Str)
+@@ -902,6 +904,9 @@ Triple::Triple(const Twine &Str)
          OS = parseOS(Components[2]);
          if (Components.size() > 3) {
            Environment = parseEnvironment(Components[3]);
@@ -53,7 +42,7 @@ index a9afcc9db96a..c4307bf457c7 100644
            ObjectFormat = parseFormat(Components[3]);
          }
        }
-@@ -853,6 +858,10 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
+@@ -953,6 +958,10 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
        ObjectFormat(parseFormat(EnvironmentStr.str())) {
    if (ObjectFormat == Triple::UnknownObjectFormat)
      ObjectFormat = getDefaultFormat(*this);
@@ -64,7 +53,7 @@ index a9afcc9db96a..c4307bf457c7 100644
  }
  
  std::string Triple::normalize(StringRef Str) {
-@@ -1103,6 +1112,9 @@ static VersionTuple parseVersionFromName(StringRef Name) {
+@@ -1207,6 +1216,9 @@ static VersionTuple parseVersionFromName(StringRef Name) {
  VersionTuple Triple::getEnvironmentVersion() const {
    StringRef EnvironmentName = getEnvironmentName();
    StringRef EnvironmentTypeName = getEnvironmentTypeName(getEnvironment());
@@ -74,11 +63,11 @@ index a9afcc9db96a..c4307bf457c7 100644
    if (EnvironmentName.startswith(EnvironmentTypeName))
      EnvironmentName = EnvironmentName.substr(EnvironmentTypeName.size());
  
-diff --git a/llvm/unittests/ADT/TripleTest.cpp b/llvm/unittests/ADT/TripleTest.cpp
-index 3006ab6d40e8..7a28ed624232 100644
---- a/llvm/unittests/ADT/TripleTest.cpp
-+++ b/llvm/unittests/ADT/TripleTest.cpp
-@@ -384,6 +384,12 @@ TEST(TripleTest, ParsedIDs) {
+diff --git a/llvm/unittests/TargetParser/TripleTest.cpp b/llvm/unittests/TargetParser/TripleTest.cpp
+index 77de43a16d0a..c25e33d2f235 100644
+--- a/llvm/unittests/TargetParser/TripleTest.cpp
++++ b/llvm/unittests/TargetParser/TripleTest.cpp
+@@ -535,6 +535,12 @@ TEST(TripleTest, ParsedIDs) {
    EXPECT_EQ(Triple::Linux, T.getOS());
    EXPECT_EQ(Triple::GNUEABI, T.getEnvironment());
  

--- a/rpm/0002-Add-Triple-isMeeGo.patch
+++ b/rpm/0002-Add-Triple-isMeeGo.patch
@@ -1,17 +1,8 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Ruben De Smet <ruben.de.smet@rubdos.be>
-Date: Sun, 26 Jun 2022 10:41:44 +0200
-Subject: [PATCH] Add Triple::isMeeGo()
-
----
- llvm/include/llvm/ADT/Triple.h | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 9e36dfd4d2d5..8e66888615ff 100644
---- a/llvm/include/llvm/ADT/Triple.h
-+++ b/llvm/include/llvm/ADT/Triple.h
-@@ -657,6 +657,9 @@ public:
+diff --git a/llvm/include/llvm/TargetParser/Triple.h b/llvm/include/llvm/TargetParser/Triple.h
+index 5bddc2a52c05..978a4231cfd8 100644
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -724,6 +724,9 @@ public:
    /// Tests whether the target is Android
    bool isAndroid() const { return getEnvironment() == Triple::Android; }
  

--- a/rpm/0003-Clang-SailfishOS-toolchain.patch
+++ b/rpm/0003-Clang-SailfishOS-toolchain.patch
@@ -1,21 +1,8 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Ruben De Smet <ruben.de.smet@rubdos.be>
-Date: Sun, 26 Jun 2022 10:57:51 +0200
-Subject: [PATCH] Clang: SailfishOS toolchain
-
-Signed-off-by: Ruben De Smet <ruben.de.smet@rubdos.be>
----
- clang/include/clang/Driver/Distro.h   | 5 +++++
- clang/lib/Driver/Distro.cpp           | 3 +++
- clang/lib/Driver/ToolChains/Gnu.cpp   | 4 +++-
- clang/lib/Driver/ToolChains/Linux.cpp | 8 ++++----
- 4 files changed, 15 insertions(+), 5 deletions(-)
-
 diff --git a/clang/include/clang/Driver/Distro.h b/clang/include/clang/Driver/Distro.h
-index 2723f75e8945..58616ad541e1 100644
+index 1aaf93ddb7c4..581a1712d997 100644
 --- a/clang/include/clang/Driver/Distro.h
 +++ b/clang/include/clang/Driver/Distro.h
-@@ -45,6 +45,7 @@ public:
+@@ -46,6 +46,7 @@ public:
      Fedora,
      Gentoo,
      OpenSUSE,
@@ -23,8 +10,8 @@ index 2723f75e8945..58616ad541e1 100644
      UbuntuHardy,
      UbuntuIntrepid,
      UbuntuJaunty,
-@@ -124,6 +125,10 @@ public:
-     return DistroVal >= DebianLenny && DistroVal <= DebianBookworm;
+@@ -127,6 +128,10 @@ public:
+     return DistroVal >= DebianLenny && DistroVal <= DebianTrixie;
    }
  
 +  bool IsSailfish() const {
@@ -32,13 +19,13 @@ index 2723f75e8945..58616ad541e1 100644
 +  }
 +
    bool IsUbuntu() const {
-     return DistroVal >= UbuntuHardy && DistroVal <= UbuntuJammy;
+     return DistroVal >= UbuntuHardy && DistroVal <= UbuntuLunar;
    }
 diff --git a/clang/lib/Driver/Distro.cpp b/clang/lib/Driver/Distro.cpp
-index 5ac38c34d112..cccb2026e527 100644
+index 87a0c5a58511..de6457bd3dfb 100644
 --- a/clang/lib/Driver/Distro.cpp
 +++ b/clang/lib/Driver/Distro.cpp
-@@ -197,6 +197,9 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
+@@ -201,6 +201,9 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
    if (VFS.exists("/etc/gentoo-release"))
      return Distro::Gentoo;
  
@@ -49,10 +36,10 @@ index 5ac38c34d112..cccb2026e527 100644
  }
  
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index 7a9570a686f4..e7f57c824961 100644
+index 4f2340316654..814f3482a1b5 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -2073,7 +2073,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2218,7 +2218,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
@@ -61,7 +48,7 @@ index 7a9570a686f4..e7f57c824961 100644
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -2082,6 +2082,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2227,6 +2227,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const ARMTriples[] = {"arm-linux-gnueabi"};
    static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
                                               "armv7hl-redhat-linux-gnueabi",
@@ -69,19 +56,19 @@ index 7a9570a686f4..e7f57c824961 100644
                                               "armv6hl-suse-linux-gnueabi",
                                               "armv7hl-suse-linux-gnueabi"};
    static const char *const ARMebLibDirs[] = {"/lib"};
-@@ -2108,6 +2109,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2257,6 +2258,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
        "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
        "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
        "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
 +      "i486-meego-linux"
    };
  
-   static const char *const M68kLibDirs[] = {"/lib"};
+   static const char *const LoongArch64LibDirs[] = {"/lib64", "/lib"};
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 83cb41159de7..e7c2dcaef02a 100644
+index c6fb290ffdb4..72ef4fff4400 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -194,7 +194,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+@@ -197,7 +197,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
    }
  
    if (Distro.IsOpenSUSE() || Distro.IsUbuntu() || Distro.IsAlpineLinux() ||
@@ -90,28 +77,20 @@ index 83cb41159de7..e7c2dcaef02a 100644
      ExtraOpts.push_back("-z");
      ExtraOpts.push_back("relro");
    }
-@@ -233,13 +233,13 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
-   // Hexagon linker/loader does not support .gnu.hash
+@@ -241,12 +241,15 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
    if (!IsMips && !IsHexagon) {
-     if (Distro.IsRedhat() || Distro.IsOpenSUSE() || Distro.IsAlpineLinux() ||
--        (Distro.IsUbuntu() && Distro >= Distro::UbuntuMaverick) ||
-+        (Distro.IsUbuntu() && Distro >= Distro::UbuntuMaverick) || Distro.IsSailfish() ||
-         (IsAndroid && !Triple.isAndroidVersionLT(23)))
-       ExtraOpts.push_back("--hash-style=gnu");
- 
-     if (Distro.IsDebian() || Distro.IsOpenSUSE() ||
-         Distro == Distro::UbuntuLucid || Distro == Distro::UbuntuJaunty ||
--        Distro == Distro::UbuntuKarmic ||
-+        Distro == Distro::UbuntuKarmic || Distro.IsSailfish() ||
-         (IsAndroid && Triple.isAndroidVersionLT(23)))
+     if (Distro.IsOpenSUSE() || Distro == Distro::UbuntuLucid ||
+         Distro == Distro::UbuntuJaunty || Distro == Distro::UbuntuKarmic ||
+-        (IsAndroid && Triple.isAndroidVersionLT(23)))
++        Distro.IsSailfish() || (IsAndroid && Triple.isAndroidVersionLT(23)))
        ExtraOpts.push_back("--hash-style=both");
+     else
+       ExtraOpts.push_back("--hash-style=gnu");
    }
-@@ -248,7 +248,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+ 
++  if (Distro.IsSailfish())
++    ExtraOpts.push_back("--enable-new-dtags");
++
+ #ifdef ENABLE_LINKER_BUILD_ID
    ExtraOpts.push_back("--build-id");
  #endif
- 
--  if (IsAndroid || Distro.IsOpenSUSE())
-+  if (IsAndroid || Distro.IsOpenSUSE() || Distro.IsSailfish())
-     ExtraOpts.push_back("--enable-new-dtags");
- 
-   // The selection of paths to try here is designed to match the patterns which

--- a/rpm/0004-Make-funwind-tables-the-default-for-all-archs.patch
+++ b/rpm/0004-Make-funwind-tables-the-default-for-all-archs.patch
@@ -1,36 +1,26 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: serge-sans-paille <sguelton@redhat.com>
-Date: Tue, 10 Dec 2019 09:18:03 +0000
-Subject: [PATCH] Make -funwind-tables the default for all archs
-
----
- clang/lib/Driver/ToolChain.cpp      | 2 +-
- clang/lib/Driver/ToolChains/Gnu.cpp | 3 +++
- 2 files changed, 4 insertions(+), 1 deletion(-)
-
 diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
-index d657d21bfcdb..eac667382fa9 100644
+index bc70205a6c01..bfd34869913f 100644
 --- a/clang/lib/Driver/ToolChain.cpp
 +++ b/clang/lib/Driver/ToolChain.cpp
-@@ -258,7 +258,7 @@ std::string ToolChain::getInputFilename(const InputInfo &Input) const {
- }
+@@ -324,7 +324,7 @@ std::string ToolChain::getInputFilename(const InputInfo &Input) const {
  
- bool ToolChain::IsUnwindTablesDefault(const ArgList &Args) const {
--  return false;
-+  return true;
+ ToolChain::UnwindTableLevel
+ ToolChain::getDefaultUnwindTableLevel(const ArgList &Args) const {
+-  return UnwindTableLevel::None;
++  return UnwindTableLevel::Asynchronous;
  }
  
  Tool *ToolChain::getClang() const {
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index e7f57c824961..9c44b2e741ce 100644
+index 814f3482a1b5..c492e45a2d0b 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -2692,6 +2692,9 @@ void Generic_GCC::printVerboseInfo(raw_ostream &OS) const {
- }
+@@ -2857,6 +2857,9 @@ void Generic_GCC::printVerboseInfo(raw_ostream &OS) const {
  
- bool Generic_GCC::IsUnwindTablesDefault(const ArgList &Args) const {
+ ToolChain::UnwindTableLevel
+ Generic_GCC::getDefaultUnwindTableLevel(const ArgList &Args) const {
 +  if (getTriple().isMeeGo()) {
-+    return true;
++    return UnwindTableLevel::Asynchronous;
 +  }
    switch (getArch()) {
    case llvm::Triple::aarch64:

--- a/rpm/0005-Disable-out-of-line-atomics-on-MeeGo.patch
+++ b/rpm/0005-Disable-out-of-line-atomics-on-MeeGo.patch
@@ -1,17 +1,8 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Ruben De Smet <ruben.de.smet@rubdos.be>
-Date: Sun, 26 Jun 2022 10:42:13 +0200
-Subject: [PATCH] Disable out-of-line atomics on MeeGo
-
----
- clang/lib/Driver/ToolChains/Linux.cpp | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index e7c2dcaef02a..9b377eca9dc8 100644
+index 72ef4fff4400..8ede9b7ce1fd 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -672,6 +672,8 @@ bool Linux::IsAArch64OutlineAtomicsDefault(const ArgList &Args) const {
+@@ -725,6 +725,8 @@ bool Linux::IsAArch64OutlineAtomicsDefault(const ArgList &Args) const {
    // and libgcc since 9.3.1
    assert(getTriple().isAArch64() && "expected AArch64 target!");
    ToolChain::RuntimeLibType RtLib = GetRuntimeLibType(Args);

--- a/rpm/clang.spec
+++ b/rpm/clang.spec
@@ -3,20 +3,20 @@
 %global patch_ver 6
 
 %global clang_tools_binaries \
+	%{_bindir}/amdgpu-arch \
 	%{_bindir}/clang-check \
 	%{_bindir}/clang-extdef-mapping \
 	%{_bindir}/clang-format \
 	%{_bindir}/clang-linker-wrapper \
-	%{_bindir}/clang-nvlink-wrapper \
 	%{_bindir}/clang-offload-bundler \
 	%{_bindir}/clang-offload-packager \
-	%{_bindir}/clang-offload-wrapper \
 	%{_bindir}/clang-refactor \
 	%{_bindir}/clang-rename \
 	%{_bindir}/clang-repl \
 	%{_bindir}/clang-scan-deps \
 	%{_bindir}/diagtool \
-	%{_bindir}/hmaptool
+	%{_bindir}/hmaptool \
+	%{_bindir}/nvptx-arch
 
 %global clang_binaries \
 	%{_bindir}/clang \
@@ -169,7 +169,12 @@ pushd clang
 mkdir -p %{buildroot}%{python3_sitelib}/clang/
 
 # install scanbuild-py to python sitelib.
+%ifarch aarch64
+mv %{buildroot}%{_prefix}/lib64/{libear,libscanbuild} %{buildroot}%{python3_sitelib}
+%else
 mv %{buildroot}%{_prefix}/lib/{libear,libscanbuild} %{buildroot}%{python3_sitelib}
+%endif
+
 
 # remove editor integrations (bbedit, sublime, emacs, vim)
 rm -vf %{buildroot}%{_datadir}/clang/clang-format-bbedit.applescript
@@ -230,8 +235,8 @@ popd
 %{_libexecdir}/intercept-cc
 %{_datadir}/scan-view/
 %{_datadir}/scan-build/
-%{python3_sitelib}/libear
-%{python3_sitelib}/libscanbuild
+%{python3_sitelib}/libear/
+%{python3_sitelib}/libscanbuild/
 
 %files tools-extra
 %{clang_tools_binaries}

--- a/rpm/clang.spec
+++ b/rpm/clang.spec
@@ -134,7 +134,7 @@ pushd build
 %endif
 	-DCLANG_INCLUDE_TESTS:BOOL=OFF \
 	-DLLVM_MAIN_SRC_DIR=%{_datadir}/llvm/src \
-%if 0%{?__isa_bits} == 64
+%ifarch aarch64
 	-DLLVM_LIBDIR_SUFFIX=64 \
 %else
 	-DLLVM_LIBDIR_SUFFIX= \


### PR DESCRIPTION
I had to modify the patches to make them apply for LLVM 16, and then I re-exported them from their respective temporary git commits. The headers were lost in the process, I can edit them back if that's what you wish.

Note: The patch 0003 I had to be creative with, so please check what I had to do with it is okay. Otherwise the patches are pretty much line number and a few filename changes only.